### PR TITLE
ci: [SWI-5336] Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -10,14 +10,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.2
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: '11'
           distribution: 'adopt'
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v6.1.0
         with:
           arguments: build
       - run: ./gradlew test

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -10,8 +10,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Set up JDK 11

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -20,6 +20,5 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - uses: gradle/actions/setup-gradle@v6.1.0
-        with:
-          arguments: build
+      - run: ./gradlew build
       - run: ./gradlew test

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       # TODO(SWI-5336): actions/create-release is archived and has no node24 release.
       # Remove this flag when a node24-compatible replacement is adopted.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,8 +26,7 @@ jobs:
         distribution: 'adopt'
 
     - uses: gradle/actions/setup-gradle@v6.1.0
-      with:
-        arguments: build
+    - run: ./gradlew build
 
     - name: Test
       run: ./gradlew test

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,17 +10,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      # TODO(SWI-5336): actions/create-release is archived and has no node24 release.
+      # Remove this flag when a node24-compatible replacement is adopted.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5.2.0
       with:
         java-version: '11'
         distribution: 'adopt'
 
-    - uses: gradle/gradle-build-action@v2
+    - uses: gradle/actions/setup-gradle@v6.1.0
       with:
         arguments: build
 
@@ -39,7 +44,7 @@ jobs:
 
     - name: Create Release on GitHub
       id: create_release
-      uses: actions/create-release@v1
+      uses: actions/create-release@v1.1.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
-    env:
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: r7kamura/semgrepper@v0

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,7 +13,9 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.2
       - uses: r7kamura/semgrepper@v0
         continue-on-error: true

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -14,7 +14,6 @@ jobs:
   run:
     runs-on: ubuntu-latest
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: r7kamura/semgrepper@v0


### PR DESCRIPTION
## Jira Ticket
https://recurly.atlassian.net/browse/SWI-5336

## Description

### Problem
GitHub Actions is deprecating Node.js 20. Actions running on Node.js 20 will be forced to Node.js 24 on June 2, 2026, and Node.js 20 will be fully removed from runners on September 16, 2026. This repo had several actions pinned to versions using node16/node12 runtimes that needed remediation.

### Fix
Updated all JavaScript GitHub Actions to Node.js 24-compatible versions:
- `actions/checkout@v3` (node16) → `@v6.0.2` (node24)
- `actions/setup-java@v3` (node16) → `@v5.2.0` (node24)
- `gradle/gradle-build-action@v2` (composite → node16) → `gradle/actions/setup-gradle@v6.1.0` (node24)
- `actions/create-release@v1` — **archived repo, no node24 release ever**. Pinned to latest `@v1.1.4` and added `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` as a temporary workaround (see below).

Validated the upgrades with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` in CI (Phase 4); flag was removed before merge (Phase 5 cleanup).

**Workaround items (require follow-up):**
| Action | File | Reason |
|--------|------|--------|
| `actions/create-release@v1.1.4` | `.github/workflows/publish.yaml` | Archived repo — no node24 release will ever be published. Consider replacing with `softprops/action-gh-release` in a future ticket. |

### Files Changed
- `.github/workflows/ci-test.yaml` — Updated checkout, setup-java, gradle-build-action
- `.github/workflows/publish.yaml` — Updated checkout, setup-java, gradle-build-action; added ACTIONS_ALLOW workaround for create-release
- `.github/workflows/semgrep.yml` — Updated checkout

## Testing
CI ran with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` active, forcing all JavaScript actions to execute under Node.js 24 to validate compatibility. Flag was removed before merge.