### PR TITLE
fix: set nexus staging packageGroup for release publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the Recurly Android SDK dependency to the build.gradle file.
 
 ```groovy
 dependencies {
-    implementation 'com.recurly:android-sdk:2.0.0'
+    implementation 'com.recurly:android-sdk:3.0.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ plugins {
 }
 
 nexusPublishing {
+    packageGroup = 'com.recurly'
+
     repositories {
         sonatype {
             // The legacy OSSRH endpoint (oss.sonatype.org) was sunset 2025-06-30


### PR DESCRIPTION
## Summary
Sets `packageGroup` on the root `nexusPublishing` config. Without it, `initializeSonatypeStagingRepository` fails to resolve a staging profile (`Failed to find staging profile for package group: `) for any non-SNAPSHOT release, since the root project has no `group` set and `AndroidSdk`'s `GROUP` property only feeds POM coordinates, not the nexus-publish-plugin's staging lookup.

## Changes
- `build.gradle`: add `packageGroup = 'com.recurly'` to `nexusPublishing`.
- `README.md`: bump documented dependency coordinate `2.0.0` -> `3.0.0`.